### PR TITLE
Rearranged topics in basics section

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright © 2016 FLYERALARM Digital GmbH 
+Copyright © 2018 FLYERALARM Digital GmbH 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ Because we think it might help others as well we open-sourced it. If you know so
 
 ## Basics
 
-* [The Absolute Minimum Every Software Developer Absolutely, Positively Must Know About Unicode and Character Sets](http://www.joelonsoftware.com/articles/Unicode.html)
-* [What Every Programmer Should Know About Memory](https://www.akkadia.org/drepper/cpumemory.pdf)
-* [What Every Developer Should Know About Time](https://unix4lyfe.org/time/?v=1)
-* [A story about an angry carrot and a floating point fairy](http://blog.ruslans.com/2014/12/a-story-about-angry-carrot-and-floating.html)
 * [How The Web Works](https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/How_the_Web_works)
 * [HTTP on Wikipedia](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)
 * [An Introduction To HTTP Basics](https://www.ntu.edu.sg/home/ehchua/programming/webprogramming/HTTP_Basics.html)
@@ -21,6 +17,10 @@ Because we think it might help others as well we open-sourced it. If you know so
 * [HTTP: The Protocol Every Web Developer Must Know](https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177)
 * [An Introduction to Networking Terminology, Interfaces, and Protocols](https://www.digitalocean.com/community/tutorials/an-introduction-to-networking-terminology-interfaces-and-protocols)
 * [How Browser Caching Works](https://thesocietea.org/2016/05/how-browser-caching-works/)
+* [The Absolute Minimum Every Software Developer Absolutely, Positively Must Know About Unicode and Character Sets](http://www.joelonsoftware.com/articles/Unicode.html)
+* [What Every Programmer Should Know About Memory](https://www.akkadia.org/drepper/cpumemory.pdf)
+* [What Every Developer Should Know About Time](https://unix4lyfe.org/time/?v=1)
+* [A story about an angry carrot and a floating point fairy](http://blog.ruslans.com/2014/12/a-story-about-angry-carrot-and-floating.html)
 
 ## Design And Architecture Of Software
 


### PR DESCRIPTION
I don't think the basic section should start with the floating point or unicode stuff. I don't want to remove it completely, so I put it at the end of the section.